### PR TITLE
Use CSS comment syntax in CSS

### DIFF
--- a/frontend/assets/styles/lcnaf.css
+++ b/frontend/assets/styles/lcnaf.css
@@ -14,7 +14,7 @@
     overflow: auto;
     margin-top: 1em; 
     margin-bottom: 1em;
-    border: 1px solid #ccc; // fallback for IE7-8
+    border: 1px solid #ccc; /* fallback for IE7-8 */
     border: 1px solid rgba(0,0,0,.15);
 }
 


### PR DESCRIPTION
This PR swaps out the scss comment syntax for css syntax. The syntax error creates an ExecJS Runtime error when the plugin's page is accessed in dev mode. It's possible this error started showing up after ArchivesSpace v3.5.0 (via the Softserv major dependency updates).

![Screen Shot 2024-05-30 at 06 42 26-fullpage](https://github.com/archivesspace-plugins/lcnaf/assets/3411019/bbcf4331-160a-40fb-9094-fb35f7086690)
