### PR TITLE
ANW-2048: Refactor plugin for consistency with recent Softserv updates

### DIFF
--- a/frontend/assets/lcnaf.js
+++ b/frontend/assets/lcnaf.js
@@ -30,9 +30,9 @@ $(function () {
         })
       );
       if (selected_lccns[record.lccn]) {
-        $('.alert-success', $result).removeClass('hide');
+        $('.alert-success', $result).removeClass('d-none');
       } else {
-        $('button', $result).removeClass('hide');
+        $('button', $result).removeClass('d-none');
       }
       $results.append($result);
     });
@@ -78,17 +78,14 @@ $(function () {
   var removeSelected = function (lccn) {
     selected_lccns[lccn] = false;
     $("[data-lccn='" + lccn + "']", $selected).remove();
-    var $result = $("[data-lccn='" + lccn + "']", $results);
-    if ($result.length > 0) {
-      $result.removeClass('hide');
-      $('.alert-success', $result)
-        .removeClass('alert-success')
-        .addClass('alert-info');
-      $result.siblings('.alert').addClass('hide');
+    var $resultSelectRecordBtn = $("[data-lccn='" + lccn + "']", $results);
+    if ($resultSelectRecordBtn.length > 0) {
+      const $result = $resultSelectRecordBtn.closest('.lcnaf-result');
+      $result.removeClass('selected');
     }
 
     if (selectedLCCNs().length === 0) {
-      $selected.siblings('.alert-info').removeClass('hide');
+      $selected.siblings('.alert-info').removeClass('d-none');
       $('#import-selected').attr('disabled', 'disabled');
     }
   };
@@ -99,13 +96,9 @@ $(function () {
       AS.renderTemplate('template_lcnaf_selected', { lccn: lccn })
     );
 
-    $('.alert-success', $result).removeClass('hide');
-    $('button.select-record', $result).addClass('hide');
-    $('.alert-info', $result)
-      .removeClass('alert-info')
-      .addClass('alert-success');
+    $result.addClass('selected');
 
-    $selected.siblings('.alert-info').addClass('hide');
+    $selected.siblings('.alert-info').addClass('d-none');
     $('#import-selected').removeAttr('disabled', 'disabled');
   };
 
@@ -214,11 +207,6 @@ $(function () {
       } else {
         addSelected(lccn, $(this).closest('.lcnaf-result'));
       }
-    })
-    .on('click', '.lcnaf-result button.show-record', function (e) {
-      e.preventDefault();
-      $(this).siblings('.lcnaf-marc').removeClass('hide');
-      $(this).addClass('hide');
     });
 
   $selected.on('click', '.remove-selected', function (event) {

--- a/frontend/assets/lcnaf.js
+++ b/frontend/assets/lcnaf.js
@@ -1,193 +1,250 @@
-$(function() {
-  var $searchForm = $("#lcnaf_search");
-  var $importForm = $("#lcnaf_import");
+$(function () {
+  var $searchForm = $('#lcnaf_search');
+  var $importForm = $('#lcnaf_import');
 
-  var $results = $("#results");
-  var $selected = $("#selected");
+  var $results = $('#results');
+  var $selected = $('#selected');
 
   var $serviceSelector = $("input[name='lcnaf_service']");
 
   var selected_lccns = {};
 
-  $('#lcnaf_service_loc').click(function() {
+  $('#lcnaf_service_loc').click(function () {
     $('#js-subjects-toggle').show();
-  })
+  });
 
-  $('#lcsh_service_loc').click(function() {
+  $('#lcsh_service_loc').click(function () {
     $('#js-subjects-toggle').hide();
-  })
+  });
 
-  var renderResults = function(json) {
+  var renderResults = function (json) {
     decorateResults(json);
 
     $results.empty();
-    $results.append(AS.renderTemplate("template_lcnaf_result_summary", json));
-    $.each(json.records, function(i, record) {
-      var $result = $(AS.renderTemplate("template_lcnaf_result", {record: record, selected: selected_lccns}));
+    $results.append(AS.renderTemplate('template_lcnaf_result_summary', json));
+    $.each(json.records, function (i, record) {
+      var $result = $(
+        AS.renderTemplate('template_lcnaf_result', {
+          record: record,
+          selected: selected_lccns
+        })
+      );
       if (selected_lccns[record.lccn]) {
-        $(".alert-success", $result).removeClass("hide");
+        $('.alert-success', $result).removeClass('hide');
       } else {
-        $("button", $result).removeClass("hide");
+        $('button', $result).removeClass('hide');
       }
       $results.append($result);
-
     });
-    $results.append(AS.renderTemplate("template_lcnaf_pagination", json));
-    $('pre code', $results).each(function(i, e) {hljs.highlightBlock(e)});
+    $results.append(AS.renderTemplate('template_lcnaf_pagination', json));
+    $('pre code', $results).each(function (i, e) {
+      hljs.highlightBlock(e);
+    });
   };
 
-
-  var decorateResults = function(resultsJson) {
+  var decorateResults = function (resultsJson) {
     //stringify the query here so templates don't need
     //to worry about SRU vs OpenSearch
-    if (typeof(resultsJson.query) === 'string') {
-      // just use sru's family_name as the 
+    if (typeof resultsJson.query === 'string') {
+      // just use sru's family_name as the
       // sole openSearch field
-      resultsJson.queryString = '?family_name=' + resultsJson.query + '&lcnaf_service=' + $("input[name='lcnaf_service']:checked").val();
+      resultsJson.queryString =
+        '?family_name=' +
+        resultsJson.query +
+        '&lcnaf_service=' +
+        $("input[name='lcnaf_service']:checked").val();
     } else {
-       if ( resultsJson.query.query['local.GivenName'] === undefined ) {
-        resultsJson.query.query['local.GivenName'] = "";  
+      if (resultsJson.query.query['local.GivenName'] === undefined) {
+        resultsJson.query.query['local.GivenName'] = '';
       }
-      resultsJson.queryString = '?family_name=' + resultsJson.query.query['local.FamilyName'] + '&given_name=' + resultsJson.query.query['local.GivenName'] + '&lcnaf_service=' + $("input[name='lcnaf_service']:checked").val();
+      resultsJson.queryString =
+        '?family_name=' +
+        resultsJson.query.query['local.FamilyName'] +
+        '&given_name=' +
+        resultsJson.query.query['local.GivenName'] +
+        '&lcnaf_service=' +
+        $("input[name='lcnaf_service']:checked").val();
     }
-  }
+  };
 
-
-  var selectedLCCNs = function() {
+  var selectedLCCNs = function () {
     var result = [];
-    $("[data-lccn]", $selected).each(function() {
-      result.push($(this).data("lccn"));
-    })
+    $('[data-lccn]', $selected).each(function () {
+      result.push($(this).data('lccn'));
+    });
     return result;
   };
 
-  var removeSelected = function(lccn) {
+  var removeSelected = function (lccn) {
     selected_lccns[lccn] = false;
-    $("[data-lccn='"+lccn+"']", $selected).remove();
-    var $result = $("[data-lccn='"+lccn+"']", $results);
+    $("[data-lccn='" + lccn + "']", $selected).remove();
+    var $result = $("[data-lccn='" + lccn + "']", $results);
     if ($result.length > 0) {
-      $result.removeClass("hide");
-      $(".alert-success", $result).removeClass("alert-success").addClass("alert-info");
-      $result.siblings(".alert").addClass("hide");
+      $result.removeClass('hide');
+      $('.alert-success', $result)
+        .removeClass('alert-success')
+        .addClass('alert-info');
+      $result.siblings('.alert').addClass('hide');
     }
 
     if (selectedLCCNs().length === 0) {
-      $selected.siblings(".alert-info").removeClass("hide");
-      $("#import-selected").attr("disabled", "disabled");
+      $selected.siblings('.alert-info').removeClass('hide');
+      $('#import-selected').attr('disabled', 'disabled');
     }
   };
 
-  var addSelected = function(lccn, $result) {
+  var addSelected = function (lccn, $result) {
     selected_lccns[lccn] = true;
-    $selected.append(AS.renderTemplate("template_lcnaf_selected", {lccn: lccn}))
+    $selected.append(
+      AS.renderTemplate('template_lcnaf_selected', { lccn: lccn })
+    );
 
-    $(".alert-success", $result).removeClass("hide");
-    $("button.select-record", $result).addClass("hide");
-    $(".alert-info", $result).removeClass("alert-info").addClass("alert-success");
+    $('.alert-success', $result).removeClass('hide');
+    $('button.select-record', $result).addClass('hide');
+    $('.alert-info', $result)
+      .removeClass('alert-info')
+      .addClass('alert-success');
 
-    $selected.siblings(".alert-info").addClass("hide");
-    $("#import-selected").removeAttr("disabled", "disabled");
+    $selected.siblings('.alert-info').addClass('hide');
+    $('#import-selected').removeAttr('disabled', 'disabled');
   };
 
-
-  var resizeSelectedBox = function() {
-    $selected.closest(".selected-container").width($selected.closest(".col-md-4").width() - 30);
+  var resizeSelectedBox = function () {
+    $selected
+      .closest('.selected-container')
+      .width($selected.closest('.col-md-4').width() - 30);
   };
-
 
   $searchForm.ajaxForm({
-    dataType: "json",
-    type: "GET",
-    beforeSubmit: function() {
-      if (!$("#family-name-search-query", $searchForm).val()) {
-          return false;
+    dataType: 'json',
+    type: 'GET',
+    beforeSubmit: function () {
+      if (!$('#family-name-search-query', $searchForm).val()) {
+        return false;
       }
 
-      $(".btn", $searchForm).attr("disabled", "disabled").addClass("disabled").addClass("busy");
+      $('.btn', $searchForm)
+        .attr('disabled', 'disabled')
+        .addClass('disabled')
+        .addClass('busy');
     },
-    success: function(json) {
-      $(".btn", $searchForm).removeAttr("disabled").removeClass("disabled").removeClass("busy");
+    success: function (json) {
+      $('.btn', $searchForm)
+        .removeAttr('disabled')
+        .removeClass('disabled')
+        .removeClass('busy');
       renderResults(json);
     },
-    error: function(err) {
-      $(".btn", $searchForm).removeAttr("disabled").removeClass("disabled").removeClass("busy");
-      var errBody = err.hasOwnProperty("responseText") ? err.responseText.replace(/\n/g, "") : "<pre>" + JSON.stringify(err) + "</pre>";
-      AS.openQuickModal(AS.renderTemplate("template_lcnaf_search_error_title"), AS.renderTemplate("template_lcnaf_search_error_message"));
+    error: function (err) {
+      $('.btn', $searchForm)
+        .removeAttr('disabled')
+        .removeClass('disabled')
+        .removeClass('busy');
+      var errBody = err.hasOwnProperty('responseText')
+        ? err.responseText.replace(/\n/g, '')
+        : '<pre>' + JSON.stringify(err) + '</pre>';
+      AS.openQuickModal(
+        AS.renderTemplate('template_lcnaf_search_error_title'),
+        AS.renderTemplate('template_lcnaf_search_error_message')
+      );
     }
   });
 
-
   $importForm.ajaxForm({
-    dataType: "json",
-    type: "POST",
-    beforeSubmit: function(data, $form, options) {
+    dataType: 'json',
+    type: 'POST',
+    beforeSubmit: function (data, $form, options) {
       data.push({
         name: 'lcnaf_service',
-        value:   $("input[name='lcnaf_service']:checked").val(),
+        value: $("input[name='lcnaf_service']:checked").val()
       });
 
-      $("#import-selected").attr("disabled", "disabled").addClass("disabled").addClass("busy");
-
+      $('#import-selected')
+        .attr('disabled', 'disabled')
+        .addClass('disabled')
+        .addClass('busy');
     },
-    success: function(json) {
-      $("#import-selected").removeClass("busy");
+    success: function (json) {
+      $('#import-selected').removeClass('busy');
       if (json.job_uri) {
-        AS.openQuickModal(AS.renderTemplate("template_lcnaf_import_success_title"), AS.renderTemplate("template_lcnaf_import_success_message"));
-        setTimeout(function() {
+        AS.openQuickModal(
+          AS.renderTemplate('template_lcnaf_import_success_title'),
+          AS.renderTemplate('template_lcnaf_import_success_message')
+        );
+        setTimeout(function () {
           window.location = json.job_uri;
         }, 2000);
       } else {
         // error
-        $("#import-selected").removeAttr("disabled").removeClass("busy")
-        AS.openQuickModal(AS.renderTemplate("template_lcnaf_import_error_title"), json.error);
+        $('#import-selected').removeAttr('disabled').removeClass('busy');
+        AS.openQuickModal(
+          AS.renderTemplate('template_lcnaf_import_error_title'),
+          json.error
+        );
       }
     },
-    error: function(err) {
-      $(".btn", $importForm).removeAttr("disabled").removeClass("disabled").removeClass("busy");
-      var errBody = err.hasOwnProperty("responseText") ? err.responseText.replace(/\n/g, "") : "<pre>" + JSON.stringify(err) + "</pre>";
-      AS.openQuickModal(AS.renderTemplate("template_lcnaf_import_error_title"), JSON.stringify(errBody));
+    error: function (err) {
+      $('.btn', $importForm)
+        .removeAttr('disabled')
+        .removeClass('disabled')
+        .removeClass('busy');
+      var errBody = err.hasOwnProperty('responseText')
+        ? err.responseText.replace(/\n/g, '')
+        : '<pre>' + JSON.stringify(err) + '</pre>';
+      AS.openQuickModal(
+        AS.renderTemplate('template_lcnaf_import_error_title'),
+        JSON.stringify(errBody)
+      );
     }
   });
 
+  $results
+    .on('click', '.lcnaf-pagination a', function (event) {
+      event.preventDefault();
 
-  $results.on("click", ".lcnaf-pagination a", function(event) {
-    event.preventDefault();
-
-    $.getJSON($(this).attr("href"), function(json) {
-      $("body").scrollTo(0); 
-      renderResults(json);
+      $.getJSON($(this).attr('href'), function (json) {
+        $('body').scrollTo(0);
+        renderResults(json);
+      });
+    })
+    .on('click', '.lcnaf-result button.select-record', function (event) {
+      var lccn = $(this).data('lccn');
+      if (selected_lccns[lccn]) {
+        removeSelected(lccn);
+      } else {
+        addSelected(lccn, $(this).closest('.lcnaf-result'));
+      }
+    })
+    .on('click', '.lcnaf-result button.show-record', function (e) {
+      e.preventDefault();
+      $(this).siblings('.lcnaf-marc').removeClass('hide');
+      $(this).addClass('hide');
     });
-  }).on("click", ".lcnaf-result button.select-record", function(event) {
-    var lccn = $(this).data("lccn");
-    if (selected_lccns[lccn]) {
-      removeSelected(lccn);
-    } else {
-      addSelected(lccn, $(this).closest(".lcnaf-result"));
-    }
-  }).on("click", ".lcnaf-result button.show-record", function(e) {
-         e.preventDefault();
-         $(this).siblings(".lcnaf-marc").removeClass("hide");
-         $(this).addClass("hide");     
-  }); 
 
-  $selected.on("click", ".remove-selected", function(event) {
+  $selected.on('click', '.remove-selected', function (event) {
     event.stopPropagation();
-    var lccn = $(this).parent().data("lccn");
+    var lccn = $(this).parent().data('lccn');
     removeSelected(lccn);
   });
 
-
-  $serviceSelector.on("click", function(event) {
+  $serviceSelector.on('click', function (event) {
     if ($selected.children().length > 0) {
       event.preventDefault();
-      AS.openQuickModal(AS.renderTemplate("template_lcnaf_service_locked_title"), AS.renderTemplate("template_lcnaf_service_locked_message"));
+      AS.openQuickModal(
+        AS.renderTemplate('template_lcnaf_service_locked_title'),
+        AS.renderTemplate('template_lcnaf_service_locked_message')
+      );
     } else {
-      $("#lcnaf_search input.lcnaf-name-input").val(''); 
-      $('#given-name-search-query').prop('disabled', function(i, v) { return !v; });
-      $('.btn', '.lcnaf-result').prop('disabled', function(i, v) { return !v; });
+      $('#lcnaf_search input.lcnaf-name-input').val('');
+      $('#given-name-search-query').prop('disabled', function (i, v) {
+        return !v;
+      });
+      $('.btn', '.lcnaf-result').prop('disabled', function (i, v) {
+        return !v;
+      });
     }
   });
 
   $(window).resize(resizeSelectedBox);
   resizeSelectedBox();
-})
+});

--- a/frontend/assets/styles/lcnaf.css
+++ b/frontend/assets/styles/lcnaf.css
@@ -1,20 +1,44 @@
-.lcnaf-result .alert button {
-  position: relative;
-  top: -7px;
+.lcnaf-result summary,
+.lcnaf-result .lcnaf-marc {
+  border: 1px solid #bce8f1;
+  border-radius: 0.25rem;
+  background-color: #d9edf7;
+  color: #006f9b;
 }
 
-.lcnaf-result .alert-success {
-  position: relative;
-  top: -16px;
+.lcnaf-result summary {
+  padding-right: 100px;
+}
+
+.lcnaf-result.selected summary,
+.lcnaf-result.selected .lcnaf-marc {
+  background-color: #dff0d8;
+  color: #3c763d;
+  border-color: #d0e6be;
+}
+
+.lcnaf-result.selected .select-record,
+.lcnaf-result [data-js-selected-label] {
+  display: none;
+}
+.lcnaf-result .select-record,
+.lcnaf-result.selected [data-js-selected-label] {
+  display: block;
+}
+
+.lcnaf-result > details[open] summary {
+  border-bottom-width: 0;
+  border-radius: 0.25rem 0.25rem 0 0;
+}
+.lcnaf-result > details[open] .lcnaf-marc {
+  border-top-width: 0;
+  border-radius: 0 0 0.25rem 0.25rem;
 }
 
 .lcnaf-marc {
   height: 200px;
   overflow: auto;
-  margin-top: 1em;
-  margin-bottom: 1em;
-  border: 1px solid #ccc; /* fallback for IE7-8 */
-  border: 1px solid rgba(0, 0, 0, 0.15);
+  margin-bottom: 1rem;
 }
 
 .lcnaf-marc pre {

--- a/frontend/assets/styles/lcnaf.css
+++ b/frontend/assets/styles/lcnaf.css
@@ -1,4 +1,4 @@
-.lcnaf-result .alert button { 
+.lcnaf-result .alert button {
   position: relative;
   top: -7px;
 }
@@ -8,46 +8,44 @@
   top: -16px;
 }
 
-
-.lcnaf-marc { 
-    height: 200px;
-    overflow: auto;
-    margin-top: 1em; 
-    margin-bottom: 1em;
-    border: 1px solid #ccc; /* fallback for IE7-8 */
-    border: 1px solid rgba(0,0,0,.15);
+.lcnaf-marc {
+  height: 200px;
+  overflow: auto;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  border: 1px solid #ccc; /* fallback for IE7-8 */
+  border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 .lcnaf-marc pre {
-    background-color: #fff;
-    border: none;
+  background-color: #fff;
+  border: none;
 }
 
 .record-pane {
-    min-height: 120px;
+  min-height: 120px;
 }
 
 .form-search,
 .selected-container {
-  border: 1px solid #DDD;
+  border: 1px solid #ddd;
   border-radius: 5px;
-  background-color: #F1F1F1;
+  background-color: #f1f1f1;
   padding: 10px;
 }
 
-
 #import-selected {
-    width: 100%;
+  width: 100%;
 }
 
 #selected {
-    margin: 10px 0 20px;
-    max-height: 200px;
-    overflow: auto;
+  margin: 10px 0 20px;
+  max-height: 200px;
+  overflow: auto;
 }
 
 .lcnaf-selected {
-    margin: 5px 0;
-    border-bottom: 1px solid #Fafafa;
-    padding: 5px 0;
+  margin: 5px 0;
+  border-bottom: 1px solid #fafafa;
+  padding: 5px 0;
 }

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -4,13 +4,12 @@ en:
       label: LCNAF Import
       authority: Authority Source
       search:
-        family_name: Primary Name 
+        family_name: Primary Name
         given_name: Rest of Name
       actions:
         search: Search
         import: Import
         select: Select
-        show_record: Show Record 
         import_subjects: Import Related Subjects?
       messages:
         none_selected: No Results Selected
@@ -24,4 +23,4 @@ en:
         service_locked: Items already selected
         service_locked_message: Please import or remove your selected items before switching record service
         service_warning: This plugin depends on 3rd party services that may or may not be available or supported.
-      result_summary: "Page %{page} - Showing results %{first_record_index} to %{last_record_index} of %{hit_count} matches"
+      result_summary: 'Page %{page} - Showing results %{first_record_index} to %{last_record_index} of %{hit_count} matches'

--- a/frontend/locales/fr.yml
+++ b/frontend/locales/fr.yml
@@ -10,7 +10,6 @@ fr:
         search: Rechercher
         import: Importer
         select: Sélectionner
-        show_record: Afficher la notice
       messages:
         none_selected: Aucun résultat sélectionné
         no_results: Pas de résultat pour la requête
@@ -23,4 +22,4 @@ fr:
         service_locked: Items déjà sélectionnés
         service_locked_message: Veuillez importer ou enlever les items sélectionnés avant de changer de service d'enregistrement
         service_warning: Ce plugin dépend de services tiers qui peuvent être ou non disponibles ou maintenus.
-      result_summary: "Page %{page} - Affichage des résultats %{first_record_index} à %{last_record_index} sur %{hit_count}"
+      result_summary: 'Page %{page} - Affichage des résultats %{first_record_index} à %{last_record_index} sur %{hit_count}'

--- a/frontend/views/lcnaf/index.html.erb
+++ b/frontend/views/lcnaf/index.html.erb
@@ -1,6 +1,6 @@
 <%= setup_context :title => "LCNAF Search" %>
 
-<div class="row">
+<div class="d-flex">
   <div class="col-md-8">
     <h2><%= I18n.t("plugins.lcnaf.label") %></h2>
 
@@ -10,17 +10,17 @@
 
     <div class='control-group form-group required'>
       <fieldset>
-      <legend class="sr-only"><%= I18n.t("plugins.lcnaf.authority") %></legend>
+        <legend class="sr-only"><%= I18n.t("plugins.lcnaf.authority") %></legend>
         <div class="radio">
           <label for="lcnaf_service_loc">
-            <input type="radio" name="lcnaf_service" value="lcnaf" id="lcnaf_service_loc" checked="true">
+            <input type="radio" name="lcnaf_service" value="lcnaf" id="lcnaf_service_loc" checked="true" />
             LCNAF - https://id.loc.gov/authorities/names
           </label>
         </div>
         <div class="radio">
           <label for="lcsh_service_loc">
-              <input type="radio" name="lcnaf_service" value="lcsh" id="lcsh_service_loc">
-           LCSH - https://id.loc.gov/authorities/subjects
+            <input type="radio" name="lcnaf_service" value="lcsh" id="lcsh_service_loc" />
+            LCSH - https://id.loc.gov/authorities/subjects
           </label>
         </div>
       </fieldset>
@@ -29,18 +29,18 @@
     <div class='control-group form-group required'> 
       <label class='control-label' for="family-name-search-query"><%= I18n.t("plugins.lcnaf.search.family_name") %></label>
       <div class='controls'> 
-        <input type="text" name="family_name" class="family-name-search-query lcnaf-name-input input-large" id="family-name-search-query"></input>
+        <input type="text" name="family_name" class="family-name-search-query lcnaf-name-input form-control" id="family-name-search-query" />
       </div>
     </div>
     <div class='control-group form-group'>
       <label for="given-name-search-query"><%= I18n.t("plugins.lcnaf.search.given_name") %></label>
       <div class='controls'> 
-        <input type="text" name="given_name" id="given-name-search-query" class="lcnaf-name-input input-large" disabled="disabled"></input>
+        <input type="text" name="given_name" id="given-name-search-query" class="lcnaf-name-input form-control" disabled="disabled" />
       </div>
     </div>
     
     <div class='control-group form-group'> 
-      <button type="submit" class="btn btn-primary btn-default">
+      <button type="submit" class="btn btn-primary">
         <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon", :alt=>"Loading..." %>
         <%= I18n.t("plugins.lcnaf.actions.search") %>
       </button>
@@ -53,14 +53,14 @@
   </div>
   <div class="col-md-4">
     <%= form_tag({:controller => :lcnaf, :action => :import}, {:id => "lcnaf_import"}) do |form| %>
-    <div class="selected-container" data-spy="affix">
+    <div class="position-fixed selected-container">
       <div class="alert alert-info"><%= I18n.t("plugins.lcnaf.messages.none_selected") %></div>
       <div id="selected"></div>
       <div id="js-subjects-toggle">
         <label class='control-label' for="import_subjects_select"><%= I18n.t("plugins.lcnaf.actions.import_subjects") %></label>
-        <input name="import_subjects" type="checkbox" id="import_subjects_select" value="1" checked> 
+        <input name="import_subjects" type="checkbox" id="import_subjects_select" value="1" checked />
       </div>
-      <button id="import-selected" class="btn btn-primary btn-default" disabled="disabled">
+      <button id="import-selected" class="btn btn-primary" disabled>
         <%= image_tag "archivesspace/btn-busy.gif", :class=>"btn-busy-icon", :alt=>"Importing..." %>
         <%= I18n.t("plugins.lcnaf.actions.import") %>
       </button>
@@ -78,35 +78,33 @@
 
 
 <div id="template_lcnaf_result"><!--
-  <div class="lcnaf-result">
-    <div class="row">
-      <div class="col-md-12">
-        <div class='alert alert-info'>${record.title}
-          <span class="pull-right alert alert-success hide"><%= I18n.t("plugins.lcnaf.messages.selected") %></span>
-          <button class="pull-right btn btn-default hide select-record" data-lccn="${record.lccn}"><%= I18n.t("plugins.lcnaf.actions.select") %></button>
-          <button class="pull-right btn btn-default hide show-record" ><%= I18n.t("plugins.lcnaf.actions.show_record") %></button>
-          <div class="col-md-12 lcnaf-marc hide"><pre><code>${record.xml|h}</code></pre></div> 
-        </div> 
-      </div>   
-    </div>
+  <div class="lcnaf-result mb-3">
+    <details class="position-relative">
+      <summary class="pl-3 py-2 rounded-top">
+        <strong>${record.title}</strong>
+        <span class="position-absolute d-flex align-items-center" style="top: .25rem; right: 1rem;">
+          <button class="btn btn-sm btn-default d-none select-record" data-lccn="${record.lccn}"><%= I18n.t("plugins.lcnaf.actions.select") %></button>
+          <span data-js-selected-label class="py-1 px-2 fs-14px cursor-default rounded bg-success text-white"><%= I18n.t("plugins.lcnaf.messages.selected") %></span>
+        </span>
+      </summary>
+      <div class="col-md-12 lcnaf-marc"><pre><code>${record.xml|h}</code></pre></div>
+    </details>
   </div>
 --></div>
 
 <div id="template_lcnaf_result_summary"><!--
-  <div class="row-fluid">
-    <div class="pull-right text-info">
-      <%= I18n.t("plugins.lcnaf.result_summary", :page => "${page}", :first_record_index => "${first_record_index}", :last_record_index => "${last_record_index}", :hit_count => "${hit_count}") %>
-    </div>
-    <hr/>
+  <hr class="mt-5" />
+  <div class="mb-4 text-right">
+    <%= I18n.t("plugins.lcnaf.result_summary", :page => "${page}", :first_record_index => "${first_record_index}", :last_record_index => "${last_record_index}", :hit_count => "${hit_count}") %>
   </div>
 --></div>
 
 <div id="template_lcnaf_pagination"><!--
-  <div class="row-fluid">
+  <div class="row-fluid mb-3">
     <hr/>
     <div class="lcnaf-pagination text-center">
-      {if !at_start}<a href='<%= url_for :controller => :lcnaf, :action => :search %>${queryString}&page=${page - 1}&records_per_page=${records_per_page}' class="btn btn-small btn-default"><%= I18n.t("pagination.previous") %> <%= I18n.t("pagination.previous_label") %></a>{/if}
-      {if !at_end}<a href='<%= url_for :controller => :lcnaf, :action => :search %>${queryString}&page=${page + 1}&records_per_page=${records_per_page}' class="btn btn-small btn-default"><%= I18n.t("pagination.next_label") %> <%= I18n.t("pagination.next") %></a>{/if}
+      {if !at_start}<a href='<%= url_for :controller => :lcnaf, :action => :search %>${queryString}&page=${page - 1}&records_per_page=${records_per_page}' class="btn btn-sm btn-default"><%= I18n.t("pagination.previous").html_safe %> <%= I18n.t("pagination.previous_label") %></a>{/if}
+      {if !at_end}<a href='<%= url_for :controller => :lcnaf, :action => :search %>${queryString}&page=${page + 1}&records_per_page=${records_per_page}' class="btn btn-sm btn-default"><%= I18n.t("pagination.next_label") %> <%= I18n.t("pagination.next").html_safe %></a>{/if}
     </div>
   </div>
 --></div>


### PR DESCRIPTION
This PR brings the lcnaf plugin in line with the recent [Softserv updates](https://github.com/archivesspace/archivesspace/commit/3041377269dcf5305208ba401b297d42e65df2fb) to ArchivesSpace core, including:

- Replace JS show/hide features with CSS and HTML `<details>`
- Update markup and styles for new Bootstrap version

[ANW-2048](https://archivesspace.atlassian.net/browse/ANW-2048)

### Before

![before-lcnaf-ANW-2048](https://github.com/archivesspace-plugins/lcnaf/assets/3411019/ca11e758-a416-4db1-a528-8b5b37bfbd1e)

### After

![after-lcnaf-ANW-2048](https://github.com/archivesspace-plugins/lcnaf/assets/3411019/066f6dbf-e8cc-49d7-9099-b8d7f16a2728)