### PR TITLE
ANW-2754 - remove unneeded form field

### DIFF
--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -4,8 +4,7 @@ en:
       label: LCNAF Import
       authority: Authority Source
       search:
-        family_name: Primary Name
-        given_name: Rest of Name
+        family_name: Name or Subject
       actions:
         search: Search
         import: Import

--- a/frontend/locales/fr.yml
+++ b/frontend/locales/fr.yml
@@ -4,8 +4,7 @@ fr:
       label: Import LCNAF
       authority: Source d'autorité
       search:
-        family_name: Partie principale
-        given_name: Reste du nom
+        family_name: Nom ou suject
       actions:
         search: Rechercher
         import: Importer

--- a/frontend/locales/fr.yml
+++ b/frontend/locales/fr.yml
@@ -4,7 +4,7 @@ fr:
       label: Import LCNAF
       authority: Source d'autorité
       search:
-        family_name: Nom ou suject
+        family_name: Nom ou sujet
       actions:
         search: Rechercher
         import: Importer

--- a/frontend/views/lcnaf/index.html.erb
+++ b/frontend/views/lcnaf/index.html.erb
@@ -32,12 +32,6 @@
         <input type="text" name="family_name" class="family-name-search-query lcnaf-name-input form-control" id="family-name-search-query" />
       </div>
     </div>
-    <div class='control-group form-group'>
-      <label for="given-name-search-query"><%= I18n.t("plugins.lcnaf.search.given_name") %></label>
-      <div class='controls'> 
-        <input type="text" name="given_name" id="given-name-search-query" class="lcnaf-name-input form-control" disabled="disabled" />
-      </div>
-    </div>
     
     <div class='control-group form-group'> 
       <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
The Rest of Name form field was relevant only to a service that was removed long ago. Updated the view and existing locale fields so that they reflect only the services that are still there.